### PR TITLE
fix(content): correct author order in BibTeX citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ If you use MOSAIC in your research, please cite:
 ```bibtex
 @misc{mousa2026mosaicunifiedplatformcrossparadigm,
       title={MOSAIC: A Universal Agent-Level Interface for Cross-Paradigm Agent Mixing and Human-AI Collaboration},
-      author={Abdulhamid M. Mousa and Jinhui Pang and Rakhmonberdi Khajiev and Jalaledin M. Azzabi and Abdulkarim M. Mousa and Peng Yong and Yunusa Haruna and Ming Liu},
+      author={Abdulhamid M. Mousa and Ming Liu and Rakhmonberdi Khajiev and Jalaledin M. Azzabi and Abdulkarim M. Mousa and Peng Yong and Yunusa Haruna and Jinhui Pang},
       year={2026},
       eprint={2603.01260},
       archivePrefix={arXiv},

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1170,7 +1170,7 @@ If you use MOSAIC in your research, please cite the following paper:
 
    @misc{mousa2026mosaicunifiedplatformcrossparadigm,
      title={MOSAIC: A Universal Agent-Level Interface for Cross-Paradigm Agent Mixing and Human-AI Collaboration},
-     author={Abdulhamid M. Mousa and Jinhui Pang and Rakhmonberdi Khajiev and Jalaledin M. Azzabi and Abdulkarim M. Mousa and Peng Yong and Yunusa Haruna and Ming Liu},
+     author={Abdulhamid M. Mousa and Ming Liu and Rakhmonberdi Khajiev and Jalaledin M. Azzabi and Abdulkarim M. Mousa and Peng Yong and Yunusa Haruna and Jinhui Pang},
      year={2026},
      eprint={2603.01260},
      archivePrefix={arXiv},


### PR DESCRIPTION
## Summary

Corrects the author ordering in BibTeX citation blocks in README.md and docs/source/index.rst.

Final author list:
1. Abdulhamid M. Mousa
2. Ming Liu
3. Rakhmonberdi Khajiev
4. Jalaledin M. Azzabi
5. Abdulkarim M. Mousa
6. Peng Yong
7. Yunusa Haruna
8. Jinhui Pang

## Files changed

- README.md
- docs/source/index.rst